### PR TITLE
Add Request ID and Host ID to error message

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -757,7 +757,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("S3:%s: %s", e.Code, e.Message)
+	return fmt.Sprintf("S3:%s: %q %q %s", e.RequestId, e.HostId, e.Code, e.Message)
 }
 
 func buildError(r *http.Response) error {
@@ -779,6 +779,12 @@ func buildError(r *http.Response) error {
 	err.StatusCode = r.StatusCode
 	if err.Message == "" {
 		err.Message = r.Status
+	}
+	if err.RequestId == "" {
+		err.RequestId = r.Header.Get("x-amz-request-id")
+	}
+	if err.HostId == "" {
+		err.HostId = r.Header.Get("x-amz-id-2")
 	}
 	if debug {
 		log.Printf("err: %#v\n", err)


### PR DESCRIPTION
AWS support will request the `x-amz-request-id` and `x-amz-id-2` when
you reach out for support.

AWS provides this information about the request ids
https://aws.amazon.com/premiumsupport/knowledge-center/s3-request-id-values/