### PR TITLE
More complete backport of signing fixes

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -635,7 +635,6 @@ func (req *request) url(full bool) (*url.URL, error) {
 		u.Opaque = "//" + u.Host + u.Opaque
 	}
 	u.RawQuery = req.params.Encode()
-	u.Path = req.path
 	return u, nil
 }
 


### PR DESCRIPTION
This PR is a complement to https://github.com/mattetti/goamz-fork/pull/12 to have a more complete backport of the signing changes done to the original library to support special and unicode characters with S3 operations. The original merge on the library is the following: https://github.com/mitchellh/goamz/commit/292a133d5117841f8c343bb423fc291725721cf0#diff-7db3cb93944d57b2ffc803281c906018R690

